### PR TITLE
Potential fix for code scanning alert no. 253: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/vulns/web/vulnerabilities.py
+++ b/src/vr/vulns/web/vulnerabilities.py
@@ -851,7 +851,7 @@ def _get_appname_assets(app_name, orderby, per_page, page, filter_list, sql_filt
     if orderby not in allowed_orderby_columns:
         raise ValueError(f"Invalid orderby column: {orderby}")
 
-    full_filter = f'({"".join(filter_list)}) AND ({sql_filter}) AND (BusinessApplications.ApplicationName = "{app_name}") AND ({VULN_STATUS_IS_NOT_CLOSED})'
+    full_filter = f'({"".join(filter_list)}) AND ({sql_filter}) AND (BusinessApplications.ApplicationName = :app_name) AND ({VULN_STATUS_IS_NOT_CLOSED})'
     vuln_all = Vulnerabilities. \
             query.with_entities(
                 Vulnerabilities.VulnerabilityID, Vulnerabilities.VulnerabilityName, Vulnerabilities.CVEID,
@@ -872,7 +872,7 @@ def _get_appname_assets(app_name, orderby, per_page, page, filter_list, sql_filt
                 Vulnerabilities.Status, Vulnerabilities.MitigationDate, BusinessApplications.ApplicationName,
                 BusinessApplications.ApplicationAcronym
             ).join(BusinessApplications, BusinessApplications.ID == Vulnerabilities.ApplicationId) \
-        .filter(text(full_filter)) \
+        .filter(text(full_filter).params(app_name=app_name)) \
         .order_by(getattr(Vulnerabilities, orderby)) \
         .yield_per(per_page) \
         .paginate(page=page, per_page=per_page, error_out=False)


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/253](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/253)

To fix the issue, the SQL query should be parameterized to prevent SQL injection. SQLAlchemy provides mechanisms for safely embedding user-controlled values into queries using bind parameters. Instead of directly interpolating `app_name` into the query string, it should be passed as a parameter to the `text()` function.

**Steps to fix:**
1. Replace the direct interpolation of `app_name` in `full_filter` with a placeholder (`:app_name`).
2. Pass `app_name` as a parameter to the `text()` function using the `params` argument.
3. Ensure that all other user-controlled inputs in the query are similarly parameterized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
