### PR TITLE
Potential fix for code scanning alert no. 255: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/vulns/web/vulnerabilities.py
+++ b/src/vr/vulns/web/vulnerabilities.py
@@ -606,8 +606,13 @@ def all_app_vulns_filtered(app_name, type, val):
             'Docker Image Name': 'DockerImageId',
             'Application Name': 'ApplicationId'
         }
-        if type in allowed_types:
-            key = allowed_types[type]
+        allowed_columns = {
+            'Docker Image Name': 'DockerImageId',
+            'Application Name': 'ApplicationId',
+            # Add other allowed mappings here
+        }
+        if type in allowed_columns:
+            key = allowed_columns[type]
             if type == 'Docker Image Name':
                 image = DockerImages.query.filter(DockerImages.ImageName == val).first()
                 val = image.ID
@@ -615,7 +620,7 @@ def all_app_vulns_filtered(app_name, type, val):
                 app = BusinessApplications.query.filter(BusinessApplications.ApplicationName == val).first()
                 val = app.ID
         else:
-            key = type.capitalize()
+            raise ValueError(f"Invalid filter type: {type}")
         if val.endswith("-"):
             filter_list = [f"{key} LIKE :val"]
             val = f"{val}%"
@@ -857,7 +862,7 @@ def _get_appname_assets(app_name, orderby, per_page, page, filter_list, sql_filt
     if orderby not in allowed_orderby_columns:
         raise ValueError(f"Invalid orderby column: {orderby}")
 
-    full_filter = f'({" AND ".join(filter_list)}) AND ({sql_filter}) AND (BusinessApplications.ApplicationName = :app_name) AND ({VULN_STATUS_IS_NOT_CLOSED})'
+    full_filter = text(f'({" AND ".join(filter_list)}) AND ({sql_filter}) AND (BusinessApplications.ApplicationName = :app_name) AND ({VULN_STATUS_IS_NOT_CLOSED})')
     vuln_all = Vulnerabilities. \
             query.with_entities(
                 Vulnerabilities.VulnerabilityID, Vulnerabilities.VulnerabilityName, Vulnerabilities.CVEID,


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/255](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/255)

To fix the issue, we need to ensure that the `key` variable is validated against a strict whitelist of allowed column names before being used in the SQL query. This will prevent any untrusted input from being directly interpolated into the query. Additionally, we should use parameterized queries for all dynamic parts of the SQL query, including `key`.

Steps to fix:
1. Validate the `key` variable against a predefined whitelist of allowed column names.
2. Use SQLAlchemy's ORM query-building capabilities or parameterized queries to safely construct the SQL query.
3. Avoid direct string interpolation for constructing SQL queries.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
