### PR TITLE
Potential fix for code scanning alert no. 259: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/vulns/web/vulnerabilities.py
+++ b/src/vr/vulns/web/vulnerabilities.py
@@ -696,6 +696,11 @@ def all_app_vulns_filtered_export(app_name, type, val):
             val = app.ID
         else:
             key = type.capitalize()
+        # Whitelist of allowed column names
+        allowed_columns = {'Severity', 'Status', 'VulnerablePackage', 'Uri', 'VulnerableFileName', 
+                           'DockerImageId', 'ApplicationId'}
+        if key not in allowed_columns:
+            return render_template('400.html', message="Invalid filter type"), 400
         if val.endswith("-"):
             filter_list = [text(f"{key} LIKE :val").bindparams(val=f"{val}%")]
         elif val == 'ALL':


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/259](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/259)

To fix the issue, the `key` variable must be validated against a whitelist of allowed column names before being used in the SQL query. This ensures that only predefined, safe column names are used in the query, eliminating the risk of SQL injection.

The fix involves:
1. Creating a whitelist of allowed column names.
2. Validating the `key` variable against this whitelist.
3. Raising an error or returning a safe response if the `key` is not in the whitelist.

This approach ensures that the SQL query is constructed safely without altering existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
