### PR TITLE
Potential fix for code scanning alert no. 214: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/api/vulns/vulnerabilities.py
+++ b/src/vr/api/vulns/vulnerabilities.py
@@ -100,7 +100,8 @@ def update_vulnerabilities_status(app_cmdb_id, scan_id, req_raw):
                 .join(VulnerabilityScans, VulnerabilityScans.ID == Vulnerabilities.ScanId) \
                 .join(DockerImages, DockerImages.ID == Vulnerabilities.DockerImageId) \
                 .filter(text(
-                f"(Vulnerabilities.Status NOT LIKE 'Closed-%' OR Vulnerabilities.Status='Closed-Mitigated') AND (Vulnerabilities.ApplicationId='{app_cmdb_id}') AND (Vulnerabilities.SourceType='{scan_type.split('CI/CD-')[1]}') AND (Vulnerabilities.InitialScanId!='{scan_id}') AND (DockerImages.ImageName='{req_raw['dockerImg']}')")) \
+                "(Vulnerabilities.Status NOT LIKE 'Closed-%' OR Vulnerabilities.Status='Closed-Mitigated') AND (Vulnerabilities.ApplicationId=:app_cmdb_id) AND (Vulnerabilities.SourceType=:source_type) AND (Vulnerabilities.InitialScanId!=:scan_id) AND (DockerImages.ImageName=:docker_img)")
+                ).params(app_cmdb_id=app_cmdb_id, source_type=scan_type.split('CI/CD-')[1], scan_id=scan_id, docker_img=req_raw['dockerImg']) \
                 .all()
     else:
         previous_vulns = Vulnerabilities\


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/214](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/214)

To fix the issue, the SQL query should use query parameters or prepared statements provided by SQLAlchemy. This ensures that user-controlled data is properly escaped and prevents SQL injection.

**Steps to fix:**
1. Replace the f-string interpolation in the SQL query with a parameterized query using `bindparam` or SQLAlchemy's query parameter syntax.
2. Pass the user-controlled value (`req_raw['dockerImg']`) as a parameter to the query instead of embedding it directly in the SQL string.
3. Ensure that all other user-controlled inputs in the query are handled similarly.

**Required changes:**
- Modify the SQL query on line 103 to use query parameters.
- Add the necessary parameter binding for `req_raw['dockerImg']`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
