### PR TITLE
Potential fix for code scanning alert no. 229: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/vulns/web/vulnerabilities.py
+++ b/src/vr/vulns/web/vulnerabilities.py
@@ -410,7 +410,7 @@ def all_vulnerabilities_filtered_export(type, val):
         # Filter Modal section
         elif type == 'Docker Image Name':
             key = 'DockerImageId'
-            image = DockerImages.query.filter(text(f"DockerImages.ImageName={val}")).first()
+            image = DockerImages.query.filter(text("DockerImages.ImageName = :image_name").params(image_name=val)).first()
             val = image.ID
         elif type == 'Application Name':
             key = 'ApplicationId'


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/229](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/229)

To fix the issue, the SQL query should use parameterized queries instead of directly interpolating user input into the query string. SQLAlchemy supports parameterized queries using placeholders and the `params()` method, which ensures that user input is properly escaped and prevents SQL injection.

Specifically:
1. Replace the f-string `f"DockerImages.ImageName={val}"` with a parameterized query using a placeholder (e.g., `:image_name`).
2. Pass the user-provided value (`val`) as a parameter to the query using the `params()` method.

This change ensures that the database driver handles escaping and quoting of the input, mitigating the risk of SQL injection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
