### PR TITLE
Potential fix for code scanning alert no. 213: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/api/vulns/vulnerabilities.py
+++ b/src/vr/api/vulns/vulnerabilities.py
@@ -84,7 +84,8 @@ def update_vulnerabilities_status(app_cmdb_id, scan_id, req_raw):
     if req_raw['findings']:
         scans = VulnerabilityScans\
             .query\
-            .filter(text(f"VulnerabilityScans.ApplicationId={app_cmdb_id} AND VulnerabilityScans.ScanType='{scan_type}'"))\
+            .filter(text("VulnerabilityScans.ApplicationId=:app_cmdb_id AND VulnerabilityScans.ScanType=:scan_type")\
+            .params(app_cmdb_id=app_cmdb_id, scan_type=scan_type))\
             .order_by(VulnerabilityScans.ID.desc())\
             .limit(2)\
             .all()


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/213](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/213)

To fix the issue, the SQL query on line 87 should be rewritten to use parameterized queries instead of directly interpolating user-controlled data. SQLAlchemy's `text()` function supports parameterized queries via the `.params()` method, which ensures that the values are properly escaped and prevents SQL injection.

Specifically:
1. Replace the f-string interpolation in the `text()` function with placeholders (e.g., `:app_cmdb_id` and `:scan_type`).
2. Use the `.params()` method to bind the actual values of `app_cmdb_id` and `scan_type` to the placeholders.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
