### PR TITLE
Potential fix for code scanning alert no. 258: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/vulns/web/vulnerabilities.py
+++ b/src/vr/vulns/web/vulnerabilities.py
@@ -707,16 +707,24 @@ def all_app_vulns_filtered_export(app_name, type, val):
         else:
             key = type.capitalize()
         # Whitelist of allowed column names
-        allowed_columns = {'Severity', 'Status', 'VulnerablePackage', 'Uri', 'VulnerableFileName', 
-                           'DockerImageId', 'ApplicationId'}
+        allowed_columns = {
+            'Severity': Vulnerabilities.Severity,
+            'Status': Vulnerabilities.Status,
+            'VulnerablePackage': Vulnerabilities.VulnerablePackage,
+            'Uri': Vulnerabilities.Uri,
+            'VulnerableFileName': Vulnerabilities.VulnerableFileName,
+            'DockerImageId': Vulnerabilities.DockerImageId,
+            'ApplicationId': Vulnerabilities.ApplicationId
+        }
         if key not in allowed_columns:
             return render_template('400.html', message="Invalid filter type"), 400
+        column = allowed_columns[key]
         if val.endswith("-"):
-            filter_list = [text(f"{key} LIKE :val").bindparams(val=f"{val}%")]
+            filter_list = [column.like(f"{val}%")]
         elif val == 'ALL':
-            filter_list = [text(f"{key} LIKE :val").bindparams(val="%-%%")]
+            filter_list = [column.like("%-%%")]
         else:
-            filter_list = [text(f"{key} = :val").bindparams(val=val)]
+            filter_list = [column == val]
 
         new_dict = {
             'db_name': 'Vulnerabilities',


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/258](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/258)

To fix the issue, we need to eliminate the dynamic construction of SQL queries using user-controlled column names. Instead, we can use a dictionary to map allowed column names to their corresponding ORM attributes or database column names. This ensures that the column names are statically defined and not directly influenced by user input.

Steps to fix:
1. Replace the dynamic SQL construction using `text()` with a dictionary-based mapping of allowed column names to their corresponding ORM attributes or database column names.
2. Use SQLAlchemy's ORM filtering methods to construct the query safely.
3. Ensure that the `val` parameter is properly sanitized and bound using query parameters.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
