### PR TITLE
Potential fix for code scanning alert no. 264: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/vulns/web/vulnerabilities.py
+++ b/src/vr/vulns/web/vulnerabilities.py
@@ -328,6 +328,17 @@ def all_vulnerabilities_filtered(type, val):
         if request.method == 'POST':
             # sort
             page, per_page, orderby_dict, orderby = update_table(request, new_dict)
+            allowed_columns = [
+                "VulnerabilityID", "VulnerabilityName", "CVEID", "CWEID", "Description", "ReleaseDate",
+                "Severity", "Classification", "Source", "LastModifiedDate", "ReferenceName", "ReferenceUrl",
+                "ReferenceTags", "AddDate", "SourceCodeFileId", "SourceCodeFileStartLine",
+                "SourceCodeFileStartCol", "SourceCodeFileEndLine", "SourceCodeFileEndCol", "DockerImageId",
+                "ApplicationId", "HostId", "Uri", "HtmlMethod", "Param", "Attack", "Evidence", "Solution",
+                "VulnerablePackage", "VulnerableFileName", "VulnerableFilePath", "Status", "MitigationDate",
+                "ApplicationName"
+            ]
+            if orderby not in allowed_columns:
+                orderby = "VulnerabilityID"  # Default safe column
         else:
             page, per_page, orderby_dict, orderby = load_table(new_dict)
 


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/264](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/264)

To fix the issue, the `orderby` parameter must be validated against a predefined list of allowed column names. This ensures that only safe, expected values are used in the SQL query. Instead of directly passing `orderby` to the `text()` function, the code should check if `orderby` matches one of the allowed column names. If it does not, a default safe value should be used.

Steps to implement the fix:
1. Define a list of allowed column names for sorting.
2. Validate the `orderby` parameter against this list.
3. If `orderby` is not in the allowed list, replace it with a default column name.
4. Use the validated `orderby` value in the query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
