### PR TITLE
Potential fix for code scanning alert no. 235: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/vulns/web/vulnerabilities.py
+++ b/src/vr/vulns/web/vulnerabilities.py
@@ -666,7 +666,7 @@ def all_app_vulns_filtered(app_name, type, val):
         table_details = _set_table_details(pg_cnt, page, vuln_all, per_page, orderby)
 
         NAV['appbar'] = 'findings'
-        app = BusinessApplications.query.filter(text(f'ApplicationName="{app_name}"')).first()
+        app = BusinessApplications.query.filter(BusinessApplications.ApplicationName == app_name).first()
         app_data = {'ID': app.ID, 'ApplicationName': app.ApplicationName}
 
         return render_template('vulns/all_app_vulns_filtered.html', entities=assets, user=user, NAV=NAV, table_details= table_details,


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/235](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/235)

To fix the problem, the SQL query should use parameterized queries instead of directly embedding user-controlled input into the query string. SQLAlchemy supports parameterized queries, which safely escape and quote user input to prevent SQL injection.

**Steps to fix:**
1. Replace the raw SQL query using `text` with a parameterized query.
2. Use SQLAlchemy's query-building methods or bind parameters to safely include `app_name` in the query.
3. Ensure that `app_name` is passed as a parameter to the query instead of being directly interpolated into the SQL string.

**Required changes:**
- Modify the query on line 669 to use parameterized queries.
- Ensure that `app_name` is passed as a parameter to the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
