### PR TITLE
Potential fix for code scanning alert no. 264: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/vulns/web/vulnerabilities.py
+++ b/src/vr/vulns/web/vulnerabilities.py
@@ -375,7 +375,7 @@ def _get_assets(orderby, per_page, page, filter_list, sql_filter):
                 .filter(text(VULN_STATUS_IS_NOT_CLOSED)) \
         .filter(text("".join(filter_list))) \
         .filter(text(sql_filter)) \
-        .order_by(text(orderby)) \
+        .order_by(getattr(Vulnerabilities, orderby)) \
         .yield_per(per_page) \
         .paginate(page=page, per_page=per_page, error_out=False)
     pg_cnt = ceil((vuln_all.total / per_page))


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/264](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/264)

To fix the issue, we need to ensure that the `orderby` variable is safely incorporated into the SQL query. The best approach is to avoid using `text()` for user-controlled input and instead use SQLAlchemy's ORM methods or parameterized queries. Specifically:
1. Validate `orderby` against the `allowed_columns` list and ensure it is used as a column name in ORM's `order_by()` method, which automatically escapes and validates input.
2. Remove the use of `text()` for `orderby` and replace it with ORM's column reference.

Changes will be made in the `_get_assets` function where the SQL query is constructed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
