### PR TITLE
Potential fix for code scanning alert no. 265: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/vulns/web/vulnerabilities.py
+++ b/src/vr/vulns/web/vulnerabilities.py
@@ -315,11 +315,14 @@ def all_vulnerabilities_filtered(type, val):
         else:
             key = type.capitalize()
         if val.endswith("-"):
-            filter_list = [f"{key} LIKE '{val}%'"]
+            filter_list = [f"{key} LIKE :val"]
+            filter_params = {"val": f"{val}%"}
         elif val == 'ALL':
-            filter_list = [f"{key} LIKE '%-%'"]
+            filter_list = [f"{key} LIKE :val"]
+            filter_params = {"val": "%-%"}
         else:
-            filter_list = [f"{key} = '{val}'"]
+            filter_list = [f"{key} = :val"]
+            filter_params = {"val": val}
 
         new_dict = {
             'db_name': 'Vulnerabilities',
@@ -373,7 +376,7 @@ def _get_assets(orderby, per_page, page, filter_list, sql_filter):
                 Vulnerabilities.Status, Vulnerabilities.MitigationDate, BusinessApplications.ApplicationName
             ).join(BusinessApplications, BusinessApplications.ID == Vulnerabilities.ApplicationId) \
                 .filter(text(VULN_STATUS_IS_NOT_CLOSED)) \
-        .filter(text("".join(filter_list))) \
+        .filter(text(" AND ".join(filter_list)).params(**filter_params)) \
         .filter(text(sql_filter)) \
         .order_by(getattr(Vulnerabilities, orderby)) \
         .yield_per(per_page) \


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/265](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/265)

To fix the issue, the SQL query should be constructed using parameterized queries instead of concatenating user-controlled input directly into the query string. SQLAlchemy supports parameterized queries, which safely embed untrusted data into SQL statements.

**Steps to fix:**
1. Replace the `text("".join(filter_list))` usage with parameterized queries.
2. Modify the construction of `filter_list` to use placeholders (`:param`) for dynamic values.
3. Pass the dynamic values as parameters to the query execution.

**Required changes:**
- Update the `filter_list` construction to use placeholders for dynamic values.
- Modify the `_get_assets` function to pass the parameters to the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
