### PR TITLE
Potential fix for code scanning alert no. 223: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/vulns/web/vulnerabilities.py
+++ b/src/vr/vulns/web/vulnerabilities.py
@@ -111,6 +111,17 @@ def all_vulnerabilities_export():
         if request.method == 'POST':
             # sort
             page, per_page, orderby_dict, orderby = update_table(request, new_dict)
+            # Validate orderby against a whitelist of allowed columns
+            allowed_columns = [
+                "VulnerabilityID", "VulnerabilityName", "CVEID", "CWEID", "Description", "ReleaseDate",
+                "Severity", "Classification", "Source", "LastModifiedDate", "ReferenceName", "ReferenceUrl",
+                "ReferenceTags", "AddDate", "SourceCodeFileId", "SourceCodeFileStartLine", "SourceCodeFileStartCol",
+                "SourceCodeFileEndLine", "SourceCodeFileEndCol", "DockerImageId", "ApplicationId", "HostId",
+                "Uri", "HtmlMethod", "Param", "Attack", "Evidence", "Solution", "VulnerablePackage",
+                "VulnerableFileName", "VulnerableFilePath", "Status", "MitigationDate", "ApplicationName"
+            ]
+            if orderby not in allowed_columns:
+                orderby = "VulnerabilityID"  # Default to a safe column
         else:
             page, per_page, orderby_dict, orderby = load_table(new_dict)
 
@@ -127,7 +138,7 @@ def all_vulnerabilities_export():
         ).join(BusinessApplications, BusinessApplications.ID==Vulnerabilities.ApplicationId) \
             .filter(text(sql_filter)) \
             .filter(text(VULN_STATUS_IS_NOT_CLOSED)) \
-            .order_by(text(orderby)) \
+            .order_by(orderby) \
             .yield_per(per_page) \
             .paginate(page=page, per_page=per_page, error_out=False)
 


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/223](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/223)

To fix the issue, we need to ensure that the `orderby` value is sanitized or validated before being used in the SQL query. The best approach is to use a whitelist of allowed column names for sorting. This ensures that only valid, predefined column names can be used in the `ORDER BY` clause, preventing SQL injection.

Steps to implement the fix:
1. Define a whitelist of allowed column names for sorting.
2. Validate the `orderby` value against this whitelist. If the value is not in the whitelist, default to a safe column name or raise an error.
3. Use the validated `orderby` value directly in the query without wrapping it in `text()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
