### PR TITLE
Potential fix for code scanning alert no. 222: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/vulns/web/vulnerabilities.py
+++ b/src/vr/vulns/web/vulnerabilities.py
@@ -48,6 +48,17 @@ def all_vulnerabilities():
         if request.method == 'POST':
             # sort
             page, per_page, orderby_dict, orderby = update_table(request, new_dict)
+            allowed_columns = [
+                "VulnerabilityID", "VulnerabilityName", "CVEID", "CWEID", "Description", "ReleaseDate", "Severity",
+                "Classification", "Source", "LastModifiedDate", "ReferenceName", "ReferenceUrl", "ReferenceTags",
+                "AddDate", "SourceCodeFileId", "SourceCodeFileStartLine", "SourceCodeFileStartCol",
+                "SourceCodeFileEndLine", "SourceCodeFileEndCol", "DockerImageId", "ApplicationId", "HostId", "Uri",
+                "HtmlMethod", "Param", "Attack", "Evidence", "Solution", "VulnerablePackage", "VulnerableFileName",
+                "VulnerableFilePath", "Status", "MitigationDate", "ApplicationName"
+            ]
+            allowed_directions = ["ASC", "DESC"]
+            if not any(orderby.startswith(col) and orderby.endswith(dir) for col in allowed_columns for dir in allowed_directions):
+                orderby = "VulnerabilityID ASC"  # Default to a safe value
         else:
             page, per_page, orderby_dict, orderby = load_table(new_dict)
 
@@ -64,7 +75,7 @@ def all_vulnerabilities():
         ).join(BusinessApplications, BusinessApplications.ID==Vulnerabilities.ApplicationId) \
             .filter(text(sql_filter)) \
             .filter(text(VULN_STATUS_IS_NOT_CLOSED)) \
-            .order_by(text(orderby)) \
+            .order_by(orderby) \
             .yield_per(per_page) \
             .paginate(page=page, per_page=per_page, error_out=False)
 


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/222](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/222)

To fix the issue, the `orderby` value must be validated or sanitized to ensure it only contains safe, expected values before being used in the SQL query. A whitelist approach is recommended, where only predefined, allowed column names and sort directions (e.g., `ASC`, `DESC`) are permitted. This ensures that user input cannot introduce malicious SQL.

The fix involves:
1. Defining a whitelist of allowed column names and sort directions.
2. Validating the `orderby` value against this whitelist.
3. Rejecting or defaulting to a safe value if the validation fails.

The changes will be made in the `all_vulnerabilities` function, specifically where `orderby` is used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
