### PR TITLE
Potential fix for code scanning alert no. 220: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/api/vulns/vulnerabilities.py
+++ b/src/vr/api/vulns/vulnerabilities.py
@@ -522,13 +522,10 @@ def edit_vulnerabilities():
         entity_id = req[list(req.keys())[0]]
         permitted = check_entity_permissions(is_admin)
         if permitted:
-            filter_db_keys = []
-            for key in src_filter:
-                val = src_filter[key].replace("'", "")
-                filter_db_keys.append(f"{key}='{val}'")
-            filter_db = " AND ".join(filter_db_keys)
-            db.session.query(Vulnerabilities).filter(text(filter_db)).update(values=req_dict,
-                                                                             synchronize_session=False)
+            query = db.session.query(Vulnerabilities)
+            for key, val in src_filter.items():
+                query = query.filter(getattr(Vulnerabilities, key) == val)
+            query.update(values=req_dict, synchronize_session=False)
             db_connection_handler(db)
             response = jsonify({"Status": "Success"}), 200
     return response


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/220](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/220)

To fix the issue, we need to avoid constructing SQL queries using string interpolation and instead use parameterized queries. SQLAlchemy provides a safe way to pass parameters to queries using placeholders and bind parameters. This ensures that user-provided data is properly escaped and prevents SQL injection.

The `filter_db` construction should be replaced with a parameterized query. Each key-value pair in `src_filter` should be added as a condition using SQLAlchemy's query-building methods, such as `filter()` or `filter_by()`. This approach eliminates the need for manual string manipulation and ensures safety.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
