### PR TITLE
Potential fix for code scanning alert no. 217: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/api/vulns/vulnerabilities.py
+++ b/src/vr/api/vulns/vulnerabilities.py
@@ -195,7 +195,10 @@ def _update_reopened_vulns(reopened_vulns):
 def get_docker_img_id(docker_img_and_tag, app_cmdb_id):
     img_name = docker_img_and_tag.split(':')[0]
     img_tag = docker_img_and_tag.split(':')[1]
-    img = DockerImages.query.filter(text(f"DockerImages.ImageName='{img_name}' AND DockerImages.ImageTag='{img_tag}'")).first()
+    img = DockerImages.query.filter(
+        text("DockerImages.ImageName = :img_name AND DockerImages.ImageTag = :img_tag")
+        .bindparams(img_name=img_name, img_tag=img_tag)
+    ).first()
     if img:
         docker_img_id = img.ID
         img_obj = img


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/217](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/217)

To fix the issue, we should replace the unsafe f-string interpolation in the SQL query with a parameterized query using SQLAlchemy's `text()` and `bindparams`. This ensures that user-controlled data is safely escaped and prevents SQL injection.

Specifically:
1. Replace the f-string in the `text()` function with placeholders (`:param_name`) for the parameters.
2. Use `bindparams` to bind the user-controlled values (`img_name` and `img_tag`) to the placeholders in a safe manner.

The changes will be made in the `get_docker_img_id` function, specifically on line 198.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
