### PR TITLE
Potential fix for code scanning alert no. 209: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/admin/routes/users.py
+++ b/src/vr/admin/routes/users.py
@@ -188,7 +188,8 @@ def remove_user_role():
         role = request.form.get('role')
         del_pair = UserRoleAssignments.query\
             .join(UserRoles, UserRoles.id == UserRoleAssignments.role_id) \
-            .filter(text(f"UserRoleAssignments.user_id={user_id} AND UserRoles.name='{role}'")).first()
+            .filter(text("UserRoleAssignments.user_id=:user_id AND UserRoles.name=:role"))\
+            .params(user_id=user_id, role=role).first()
         if del_pair:
             db.session.delete(del_pair)
             db_connection_handler(db)


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/209](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/209)

To fix the issue, we need to replace the unsafe f-string interpolation with a parameterized query. SQLAlchemy supports parameterized queries using the `text` function with bound parameters. This approach ensures that user-provided values are properly escaped and prevents SQL injection.

Specifically:
1. Replace the f-string in the `text` function with placeholders (`:user_id` and `:role`).
2. Pass the user-provided values (`user_id` and `role`) as parameters to the query.

This change ensures that the database driver handles escaping and quoting of the parameters, eliminating the risk of SQL injection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
