### PR TITLE
Potential fix for code scanning alert no. 200: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/threat_modeling/routes/threat_modeler.py
+++ b/src/vr/threat_modeling/routes/threat_modeler.py
@@ -122,6 +122,11 @@ def threat_assessments(id):
         if request.method == 'POST':
             # sort
             page, per_page, orderby_dict, orderby = update_table(request, new_dict, direction="desc")
+
+            # Validate orderby against allowed columns
+            allowed_columns = ["ID", "AddDate", "username", "Status", "findings_cnt", "ApplicationName"]
+            if orderby not in allowed_columns:
+                orderby = "ID"  # Default to a safe column if validation fails
         else:
             page, per_page, orderby_dict, orderby = load_table(new_dict, direction="desc")
 
@@ -139,7 +144,7 @@ def threat_assessments(id):
             .join(User, User.id == TmThreatAssessments.SubmitUserID, isouter=True) \
             .group_by(TmThreatAssessments.ID) \
             .filter(text("".join(filter_list))) \
-            .order_by(text(orderby)) \
+            .order_by(orderby) \
             .yield_per(per_page) \
             .paginate(page=page, per_page=per_page, error_out=False)
 


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/200](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/200)

To fix the issue, we need to ensure that the `orderby` variable is sanitized or validated before being used in the SQL query. The best approach is to validate `orderby` against a predefined list of allowed column names. This ensures that only safe values are used in the query, preventing SQL injection.

Steps to implement the fix:
1. Define a list of allowed column names for sorting.
2. Validate the `orderby` variable against this list.
3. If `orderby` is not valid, default to a safe value or raise an error.
4. Replace the use of `text(orderby)` with a safe, validated value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
