### PR TITLE
Potential fix for code scanning alert no. 267: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/threat_modeling/routes/threat_modeler.py
+++ b/src/vr/threat_modeling/routes/threat_modeler.py
@@ -110,9 +110,7 @@ def threat_assessments(id):
         elif status == 403:
             return render_template(UNAUTH_STATUS, user=user, NAV=NAV)
 
-        key = 'BusinessApplications.ID'
-        val = id
-        filter_list = [f"{key} = '{val}'"]
+        filter_condition = (BusinessApplications.ID == id)
 
         new_dict = {
             'db_name': 'TmThreatAssessments',
@@ -143,7 +141,7 @@ def threat_assessments(id):
             .join(TmIdentifiedThreats, TmIdentifiedThreats.ThreatAssessmentID == TmThreatAssessments.ID, isouter=True) \
             .join(User, User.id == TmThreatAssessments.SubmitUserID, isouter=True) \
             .group_by(TmThreatAssessments.ID) \
-            .filter(text("".join(filter_list))) \
+            .filter(filter_condition) \
             .order_by(orderby) \
             .yield_per(per_page) \
             .paginate(page=page, per_page=per_page, error_out=False)


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/267](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/267)

To fix the issue, the SQL query should be parameterized to prevent SQL injection. SQLAlchemy provides a safe way to include user-provided values in queries using bind parameters. Instead of constructing the query string manually with `filter_list` and `text`, we can use parameterized queries with placeholders and pass the user-provided values as parameters.

Specifically:
1. Replace the construction of `filter_list` with a parameterized query filter.
2. Use SQLAlchemy's query filtering methods (e.g., `.filter()`) with bind parameters instead of raw SQL strings.
3. Ensure that the `id` parameter is passed as a bind parameter to the query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
