### PR TITLE
Potential fix for code scanning alert no. 199: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/vulns/web/testing.py
+++ b/src/vr/vulns/web/testing.py
@@ -46,6 +46,12 @@ def vulnerability_scans(id):
         if request.method == 'POST':
             # sort
             page, per_page, orderby_dict, orderby = update_table(request, new_dict)
+            allowed_columns = ["ID", "ScanName", "ScanType", "ScanTargets", "ScanStartDate", "issue_cnt", "open_issue_cnt", "closed_issue_cnt", "ra_issue_cnt"]
+            allowed_directions = ["asc", "desc"]
+            if orderby_dict.get("column") in allowed_columns and orderby_dict.get("direction") in allowed_directions:
+                orderby = f"{orderby_dict['column']} {orderby_dict['direction']}"
+            else:
+                orderby = "ID asc"  # Default order
         else:
             page, per_page, orderby_dict, orderby = load_table(new_dict)
 


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/199](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/199)

To fix the issue, the `orderby` variable should be sanitized or validated before being used in the SQL query. The best approach is to use parameterized queries or restrict `orderby` to a predefined set of safe values (e.g., column names and sorting directions). This ensures that only valid and safe SQL fragments are used in the query.

Steps to implement the fix:
1. Define a whitelist of allowed column names and sorting directions for `orderby`.
2. Validate the `orderby` value against the whitelist before constructing the query.
3. Replace the direct use of `text(orderby)` with a safe mechanism that uses validated input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
