### PR TITLE
Potential fix for code scanning alert no. 199: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/vulns/web/testing.py
+++ b/src/vr/vulns/web/testing.py
@@ -49,9 +49,11 @@ def vulnerability_scans(id):
             allowed_columns = ["ID", "ScanName", "ScanType", "ScanTargets", "ScanStartDate", "issue_cnt", "open_issue_cnt", "closed_issue_cnt", "ra_issue_cnt"]
             allowed_directions = ["asc", "desc"]
             if orderby_dict.get("column") in allowed_columns and orderby_dict.get("direction") in allowed_directions:
-                orderby = f"{orderby_dict['column']} {orderby_dict['direction']}"
+                column = getattr(VulnerabilityScans, orderby_dict['column'], None)
+                direction = orderby_dict['direction']
+                orderby = column.asc() if direction == "asc" else column.desc()
             else:
-                orderby = "ID asc"  # Default order
+                orderby = VulnerabilityScans.ID.asc()  # Default order
         else:
             page, per_page, orderby_dict, orderby = load_table(new_dict)
 
@@ -66,7 +68,7 @@ def vulnerability_scans(id):
             .join(Vulnerabilities, Vulnerabilities.InitialScanId == VulnerabilityScans.ID, isouter=True) \
             .group_by(VulnerabilityScans.ID) \
             .filter(text("".join(filter_list))) \
-            .order_by(text(orderby)) \
+            .order_by(orderby) \
             .yield_per(per_page) \
             .paginate(page=page, per_page=per_page, error_out=False)
         pg_cnt = ceil((vuln_all.total / per_page))


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/199](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/199)

To fix the issue, we need to ensure that the `orderby` value is safely embedded into the SQL query. Instead of constructing the `orderby` string manually and passing it to `text()`, we can use SQLAlchemy's ORM methods or query parameters to safely handle user input. Specifically, we can validate the `orderby_dict` values and use SQLAlchemy's `asc()` and `desc()` functions to dynamically set the ordering direction without directly embedding user-controlled strings.

Changes required:
1. Replace the manual construction of `orderby` with a safe approach using SQLAlchemy's ORM methods (`asc()` and `desc()`).
2. Remove the use of `text(orderby)` and replace it with ORM-compatible ordering methods.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
