### PR TITLE
Potential fix for code scanning alert no. 196: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/threat_modeling/routes/threat_modeler.py
+++ b/src/vr/threat_modeling/routes/threat_modeler.py
@@ -72,7 +72,7 @@ def threat_modeler(id):
                 db.session.add(new_solution)
                 db_connection_handler(db)
                 NAV['appbar'] = 'threat_models'
-                app = BusinessApplications.query.filter(text(f'ID={id}')).first()
+                app = BusinessApplications.query.filter(text('ID=:id').params(id=id)).first()
                 app_data = {'ID': id, 'ApplicationName': app.ApplicationName}
             return render_template('threat_modeling/threat_report.html', user=user, NAV=NAV, threats=threats,
                                    controls=controls, num_threats_mitigated=len(threats_mitigated), app_data=app_data)
@@ -87,7 +87,7 @@ def threat_modeler(id):
                 }
             }
             NAV['appbar'] = 'threat_models'
-            app = BusinessApplications.query.filter(text(f'ID={id}')).first()
+            app = BusinessApplications.query.filter(text('ID=:id').params(id=id)).first()
             app_data = {'ID': id, 'ApplicationName': app.ApplicationName, 'Component': app.ApplicationAcronym}
             return render_template('threat_modeling/threat_modeler.html', app_data=app_data, user=user, NAV=NAV, questions=questions, application_questions=application_questions)
     except RuntimeError:


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/196](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/196)

To fix the issue, the SQL query should be parameterized to prevent SQL injection. SQLAlchemy supports parameterized queries, which safely embed user-provided values into SQL statements. Instead of using `text(f'ID={id}')`, the query should use a parameterized `text` object with a placeholder for the `id` value, and the value should be passed as a parameter.

The specific changes are:
1. Replace `text(f'ID={id}')` with `text('ID=:id')`.
2. Pass the `id` value as a parameter to the query using the `params` method or by passing a dictionary of parameters.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
