### PR TITLE
Potential fix for code scanning alert no. 190: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/sourcecode/web/sourcecode_files.py
+++ b/src/vr/sourcecode/web/sourcecode_files.py
@@ -62,7 +62,7 @@ def sourcecode_files(id):
         assets = schema.dump(components.items)
 
         NAV['appbar'] = 'components'
-        app = BusinessApplications.query.filter(text(f'ID={id}')).first()
+        app = BusinessApplications.query.filter(text('ID = :id').params(id=id)).first()
         app_data = {'ID': id, 'ApplicationName': app.ApplicationName, 'Component': app.ApplicationAcronym}
 
         table_details = {


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/190](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/190)

To fix the issue, the SQL query should use parameterized queries instead of directly embedding user-controlled values into the query string. SQLAlchemy supports parameterized queries, which safely escape and handle user input.

**Steps to fix:**
1. Replace the `text(f'ID={id}')` usage with a parameterized query using SQLAlchemy's `bindparam` or query parameters.
2. Ensure that the `id` value is passed as a parameter to the query, rather than being directly interpolated into the SQL string.

**Required changes:**
- Modify the query on line 65 to use parameterized input.
- No new imports or definitions are needed, as SQLAlchemy already supports parameterized queries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
