### PR TITLE
Potential fix for code scanning alert no. 189: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/sourcecode/web/sourcecode_files.py
+++ b/src/vr/sourcecode/web/sourcecode_files.py
@@ -46,6 +46,11 @@ def sourcecode_files(id):
         else:
             page, per_page, orderby_dict, orderby = load_table(new_dict)
 
+        # Validate orderby against a whitelist of allowed values
+        allowed_orderby_fields = ["VulnerableFileName", "findings_cnt"]
+        if orderby not in allowed_orderby_fields:
+            raise ValueError(f"Invalid orderby value: {orderby}")
+
         components = Vulnerabilities.query.with_entities(
             Vulnerabilities.VulnerableFileName,
             func.count(Vulnerabilities.VulnerabilityID).label('findings_cnt')


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/189](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/189)

To fix the issue, the `orderby` value must be sanitized or validated to ensure it only contains safe values before being used in the SQL query. The best approach is to restrict `orderby` to a predefined set of allowed column names or sorting directions. This can be achieved by:
1. Defining a whitelist of valid column names and sorting directions.
2. Validating `orderby` against this whitelist before constructing the query.
3. Using parameterized queries wherever possible to avoid direct embedding of user-controlled values.

Changes will be made to ensure `orderby` is validated before being passed to `text()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
