### PR TITLE
Potential fix for code scanning alert no. 189: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/sourcecode/web/sourcecode_files.py
+++ b/src/vr/sourcecode/web/sourcecode_files.py
@@ -46,7 +46,10 @@ def sourcecode_files(id):
             page, per_page, orderby_dict, orderby = load_table(new_dict)
 
         # Validate orderby against a whitelist of allowed values
-        allowed_orderby_fields = ["VulnerableFileName", "findings_cnt"]
+        allowed_orderby_fields = {
+            "VulnerableFileName": Vulnerabilities.VulnerableFileName,
+            "findings_cnt": func.count(Vulnerabilities.VulnerabilityID).label('findings_cnt')
+        }
         if orderby not in allowed_orderby_fields:
             raise ValueError(f"Invalid orderby value: {orderby}")
 
@@ -57,7 +60,7 @@ def sourcecode_files(id):
             .filter(filter) \
             .filter(text("Vulnerabilities.Classification LIKE 'IaC%' OR Vulnerabilities.Classification LIKE 'SAST%' OR Vulnerabilities.Classification LIKE 'Secret%'")) \
             .group_by(Vulnerabilities.VulnerableFileName) \
-            .order_by(text(orderby)) \
+            .order_by(allowed_orderby_fields[orderby]) \
             .yield_per(per_page) \
             .paginate(page=page, per_page=per_page, error_out=False)
 


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/189](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/189)

To fix the issue, we need to ensure that the `orderby` value is safely incorporated into the SQL query. Instead of using `text(orderby)`, we can use SQLAlchemy's ORM capabilities to dynamically construct the `order_by` clause with column references. This approach avoids the need for raw SQL fragments and ensures that the query is safe from SQL injection.

Steps to fix:
1. Replace the `text(orderby)` usage with a dynamic column reference using SQLAlchemy's ORM.
2. Map the allowed `orderby` values to their corresponding column objects in the `Vulnerabilities` model.
3. Use the mapped column object in the `order_by` clause instead of raw SQL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
