### PR TITLE
Potential fix for code scanning alert no. 187: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/assets/web/settings.py
+++ b/src/vr/assets/web/settings.py
@@ -429,8 +429,10 @@ def remove_cicd_pipeline():
             return render_template('403.html', user=user, NAV=NAV)
 
         pipeline_id = request.form.get('pipeline_id')
+        if not pipeline_id.isdigit():
+            return render_template('400.html'), 400
         del_pair = CICDPipelines.query\
-            .filter(text(f"CICDPipelines.ID={pipeline_id}")).first()
+            .filter(CICDPipelines.ID == pipeline_id).first()
         if del_pair:
             db.session.delete(del_pair)
             db_connection_handler(db)


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/187](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/187)

To fix the issue, the SQL query should use parameterized queries instead of directly embedding user-controlled input into the query string. SQLAlchemy supports parameterized queries, which safely handle user input by escaping it appropriately. This eliminates the risk of SQL injection.

**Steps to fix:**
1. Replace the `text()` function with a parameterized query using SQLAlchemy's query filters.
2. Pass `pipeline_id` as a parameter to the query instead of embedding it directly in the SQL string.
3. Ensure that `pipeline_id` is validated (e.g., check if it is a valid integer) before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
