### PR TITLE
Potential fix for code scanning alert no. 184: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/assets/web/settings.py
+++ b/src/vr/assets/web/settings.py
@@ -360,7 +360,7 @@ def add_cicd_pipeline(app_id):
             AppIntegrations.query
                 .with_entities(Integrations.ID, Integrations.Name, AppIntegrations.ID, AppIntegrations.AppEntity)
                 .join(Integrations, Integrations.ID == AppIntegrations.IntegrationID)  # Explicit join condition
-                .filter(text(f"Integrations.ToolType='Jenkins' AND AppIntegrations.AppID={app_id}"))
+                .filter(text("Integrations.ToolType='Jenkins' AND AppIntegrations.AppID=:app_id").params(app_id=app_id))
                 .first()
         )
         if request.method == 'POST':


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/184](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/184)

To fix the issue, the SQL query should use parameterized queries instead of directly interpolating user-controlled values into the query string. SQLAlchemy supports parameterized queries using the `.params()` method, which safely escapes and binds user-provided values to placeholders in the query.

**Steps to fix:**
1. Replace the f-string interpolation in the `text()` function with a placeholder (`:app_id`).
2. Use the `.params()` method to bind the `app_id` value to the placeholder.

**Changes needed:**
- Modify the SQL query on line 363 to use a parameterized query.
- Bind the `app_id` value using `.params(app_id=app_id)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
