### PR TITLE
Potential fix for code scanning alert no. 169: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/orchestration/web/pipeline_jobs.py
+++ b/src/vr/orchestration/web/pipeline_jobs.py
@@ -103,7 +103,14 @@ def pipeline_jobs(id):
 
         if request.method == 'POST':
             # sort
-            page, per_page, orderby_dict, orderby = update_table(request, new_dict, direction="desc")
+            page, per_page, orderby_dict, raw_orderby = update_table(request, new_dict, direction="desc")
+            allowed_columns = ["ID", "StartDate", "BuildNum", "ApplicationName", "PipelineSource", "BranchName", "JobName", "Project", "GitBranch"]
+            allowed_directions = ["asc", "desc"]
+            orderby_parts = raw_orderby.split()
+            if len(orderby_parts) == 2 and orderby_parts[0] in allowed_columns and orderby_parts[1].lower() in allowed_directions:
+                orderby = f"{orderby_parts[0]} {orderby_parts[1].upper()}"
+            else:
+                raise ValueError("Invalid orderby value")
         else:
             page, per_page, orderby_dict, orderby = load_table(new_dict, direction="desc")
 


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/169](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/169)

To fix the issue, we need to ensure that the `orderby` value is sanitized or validated before being used in the SQL query. The best approach is to use a whitelist of allowed column names and directions (e.g., `ASC` or `DESC`) to construct the `orderby` clause safely. This avoids directly embedding user-controlled input into the query.

Steps to fix:
1. Define a whitelist of allowed column names and sort directions.
2. Validate the `orderby` value against the whitelist.
3. Construct the `orderby` clause programmatically using safe values.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
