### PR TITLE
Potential fix for code scanning alert no. 167: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/orchestration/web/pipeline_jobs.py
+++ b/src/vr/orchestration/web/pipeline_jobs.py
@@ -40,11 +40,19 @@ def all_pipeline_jobs():
             "sort_field": "ID"
         }
 
+        # Define a whitelist of allowed column names for sorting
+        allowed_sort_fields = {"ID", "PipelineName", "StartDate", "BuildNum", "ApplicationName", 
+                               "PipelineSource", "BranchName", "JobName", "Project", "GitBranch"}
+
         if request.method == 'POST':
             # sort
             page, per_page, orderby_dict, orderby = update_table(request, new_dict, direction="desc")
         else:
             page, per_page, orderby_dict, orderby = load_table(new_dict, direction="desc")
+
+        # Validate the orderby field against the whitelist
+        if orderby not in allowed_sort_fields:
+            orderby = "ID"  # Default to a safe value if validation fails
 
         assets_all = PipelineJobs.query\
             .with_entities(PipelineJobs.ID, CICDPipelines.Name.label('PipelineName'), PipelineJobs.StartDate,


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/167](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/167)

To fix the issue, we need to ensure that the `orderby` variable is sanitized or validated before being used in the query. The best approach is to restrict `orderby` to a predefined set of safe column names. This can be achieved by:
1. Defining a whitelist of allowed column names for sorting.
2. Validating the `orderby` value against this whitelist.
3. Rejecting or defaulting to a safe value if the user-provided `orderby` is not in the whitelist.

This fix ensures that only safe, predefined column names are used in the query, preventing SQL injection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
