### PR TITLE
Potential fix for code scanning alert no. 167: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/orchestration/web/pipeline_jobs.py
+++ b/src/vr/orchestration/web/pipeline_jobs.py
@@ -54,6 +54,20 @@ def all_pipeline_jobs():
         if orderby not in allowed_sort_fields:
             orderby = "ID"  # Default to a safe value if validation fails
 
+        # Map orderby to a valid column object
+        orderby_column = {
+            "ID": PipelineJobs.ID,
+            "PipelineName": CICDPipelines.Name,
+            "StartDate": PipelineJobs.StartDate,
+            "BuildNum": PipelineJobs.BuildNum,
+            "ApplicationName": BusinessApplications.ApplicationName,
+            "PipelineSource": CICDPipelines.Source,
+            "BranchName": PipelineJobs.BranchName,
+            "JobName": PipelineJobs.JobName,
+            "Project": PipelineJobs.Project,
+            "GitBranch": PipelineJobs.GitBranch
+        }.get(orderby, PipelineJobs.ID)  # Default to PipelineJobs.ID if orderby is invalid
+
         assets_all = PipelineJobs.query\
             .with_entities(PipelineJobs.ID, CICDPipelines.Name.label('PipelineName'), PipelineJobs.StartDate,
                            PipelineJobs.BuildNum, BusinessApplications.ApplicationName, CICDPipelines.Source.label('PipelineSource'),
@@ -62,7 +76,7 @@ def all_pipeline_jobs():
             .join(BusinessApplications, BusinessApplications.ID == PipelineJobs.ApplicationId, isouter=True) \
             .join(CICDPipelines, PipelineJobs.Source == CICDPipelines.ID, isouter=True) \
             .filter(text(sql_filter)) \
-            .order_by(text(orderby)) \
+            .order_by(orderby_column) \
             .yield_per(per_page) \
             .paginate(page=page, per_page=per_page, error_out=False)
 


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/167](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/167)

To fix the issue, we need to eliminate the use of `text()` for the `orderby` clause and instead use SQLAlchemy's ORM mechanisms to safely construct the query. Specifically:
1. Replace the `text(orderby)` with a dynamically constructed column reference using SQLAlchemy's ORM.
2. Ensure that the `orderby` value is mapped to a valid column object from the `PipelineJobs` model or related models.
3. This approach avoids raw SQL fragments and leverages SQLAlchemy's built-in protections against SQL injection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
