### PR TITLE
Potential fix for code scanning alert no. 163: SQL query built from user-controlled sources

### DIFF
--- a/src/vr/vulns/web/metrics.py
+++ b/src/vr/vulns/web/metrics.py
@@ -484,7 +484,7 @@ def get_kpi_tree(entity_id, scope='Component', start_date=None, end_date=None):
             .filter(text(filter_str)).all()
     elif scope == 'Global':
         if start_date:
-            filter_str = f'CICDPipelineBuilds.StartTime BETWEEN "{start_date}" AND "{end_date}"'
+            filter_str = 'CICDPipelineBuilds.StartTime BETWEEN :start_date AND :end_date'
             stages_all = CICDPipelineStageData.query \
                 .with_entities(
                 CICDPipelineStageData.ID, CICDPipelineStageData.AddDate, CICDPipelineStageData.BuildNode,
@@ -495,7 +495,7 @@ def get_kpi_tree(entity_id, scope='Component', start_date=None, end_date=None):
             ) \
                 .join(CICDPipelineBuilds, CICDPipelineBuilds.ID == CICDPipelineStageData.BuildID) \
                 .join(CICDPipelines, CICDPipelines.ID == CICDPipelineBuilds.PipelineID) \
-                .filter(text(filter_str)).all()
+                .filter(text(filter_str)).params(start_date=start_date, end_date=end_date).all()
         else:
             stages_all = CICDPipelineStageData.query \
                 .with_entities(


### PR DESCRIPTION
Potential fix for [https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/163](https://github.com/SecurityUniversalOrg/SecuSphere/security/code-scanning/163)

To fix the issue, we need to ensure that user-provided inputs (`start_date` and `end_date`) are safely embedded into the SQL query. This can be achieved by using SQLAlchemy's parameterized query mechanism instead of directly constructing the SQL string with `text()`.

1. Replace the construction of `filter_str` with a parameterized query. Use placeholders (`:start_date`, `:end_date`) in the SQL string and pass the actual values as parameters to the `filter` method.
2. Modify the `filter` calls on line 498 (and similar lines) to use these placeholders and pass the parameters as a dictionary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
